### PR TITLE
TE-1824: increased the max length to 36 from 30 on pspTransactionId field

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -548,7 +548,7 @@ definitions:
         type: string
         example: 7686f7788898767977
         pattern: "[a-z0-9]"
-        maxLength: 30
+        maxLength: 36
         description: Used as a globally unique per PSP transaction reference for the PSP systems
       merchantOrderId:
         type: string


### PR DESCRIPTION
TE-1824: increased the max length to 36 from 30 on pspTransactionId field